### PR TITLE
[Bugfix] Fix extractor for iCal with no events

### DIFF
--- a/src/events-extractors/ical.ts
+++ b/src/events-extractors/ical.ts
@@ -10,7 +10,7 @@ export function extractEventsFromICal(
 
 	const vCalendar = (iCalendarJSONData.VCALENDAR as JSONCal)[0] as JSONCal
 	const calendarTimeZone = vCalendar["X-WR-TIMEZONE"] as string
-	const vEvents = vCalendar.VEVENT as JSONCal[]
+	const vEvents = vCalendar.VEVENT as JSONCal[] ?? []
 	return vEvents
 		.map((vEvent) => {
 			const keys = Object.keys(vEvent)

--- a/tests/extractors/ical.spec.ts
+++ b/tests/extractors/ical.spec.ts
@@ -3,9 +3,11 @@ import dayjs from "dayjs"
 import { extractEventsFromCalendar } from "../../src/events-extractors/extractor"
 
 import iCalTestJSON from "../resources/calendar-ical.json"
+import iCalTestEmptyJSON from "../resources/calendar-ical-empty.json"
 import { TimeSlotsFinderCalendarFormat } from "../../src"
 
 const iCalData = (iCalTestJSON as unknown as { data: string }).data
+const iCalEmptyData = (iCalTestEmptyJSON as unknown as { data: string }).data
 
 describe("iCal calendar extractor", () => {
 	it("should properly extract events from iCal formatted strings", () => {
@@ -72,5 +74,14 @@ describe("iCal calendar extractor", () => {
 			iCalData
 		)
 		expect(events2[0].startAt.format("Z")).toBe("+11:00")
+	})
+	it("should not throw for empty calendar", () => {
+		const events = extractEventsFromCalendar(
+			"Europe/Paris",
+			TimeSlotsFinderCalendarFormat.iCal,
+			iCalEmptyData
+		)
+		expect(Array.isArray(events)).toBe(true)
+		expect(events.length).toBe(0)
 	})
 })

--- a/tests/resources/calendar-ical-empty.json
+++ b/tests/resources/calendar-ical-empty.json
@@ -1,0 +1,1 @@
+{ "data": "BEGIN:VCALENDAR\nPRODID:-//Google Inc//Google Calendar 70.9054//EN\nVERSION:2.0\nCALSCALE:GREGORIAN\nMETHOD:PUBLISH\nX-WR-CALNAME:Time Slots Service Test\nX-WR-TIMEZONE:Europe/Paris\nEND:VCALENDAR\n" }


### PR DESCRIPTION
When trying to compute slots taking in account an iCal calendar without any events, the module throw `Cannot read property 'map' of undefined` error.

This Pull Request is fixing this and add non-regression unit test.