### PR TITLE
[Bugfix] Remove local test and fix parsing of from and to dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "jest",
     "build": "tsc",
     "prepublishOnly": "yarn build",
-    "preversion": "sh ./scripts/preversion.sh && yarn test --ci",
+    "preversion": "sh ./scripts/preversion.sh",
     "postversion": "git push && git push --tags && sh ./scripts/changesloglink.sh"
   },
   "devDependencies": {

--- a/src/time-slots.ts
+++ b/src/time-slots.ts
@@ -111,15 +111,15 @@ function _computeBoundaries(from: Date, to: Date, configuration: TimeSlotsFinder
 		: null
 
 	const firstFromMoment = dayjs.max(
-		dayjs.tz(from, configuration.timeZone),
+		dayjs(from).tz(configuration.timeZone),
 		dayjs().tz(configuration.timeZone)
 			/* `minAvailableTimeBeforeSlot` will be subtract later and it cannot start before now */
 			.add(configuration.minAvailableTimeBeforeSlot ?? 0, "minute")
 			.add(configuration.minTimeBeforeFirstSlot ?? 0, "minute"),
 	)
 	const lastToMoment = searchLimitMoment
-		? dayjs.min(dayjs.tz(to, configuration.timeZone), searchLimitMoment)
-		: dayjs.tz(to, configuration.timeZone)
+		? dayjs.min(dayjs(to).tz(configuration.timeZone), searchLimitMoment)
+		: dayjs(to).tz(configuration.timeZone)
 
 	return { firstFromMoment, lastToMoment }
 }

--- a/tests/extractors/ical.spec.ts
+++ b/tests/extractors/ical.spec.ts
@@ -5,11 +5,14 @@ import { extractEventsFromCalendar } from "../../src/events-extractors/extractor
 import iCalTestJSON from "../resources/calendar-ical.json"
 import iCalTestEmptyJSON from "../resources/calendar-ical-empty.json"
 import { TimeSlotsFinderCalendarFormat } from "../../src"
+import MockDate from "mockdate"
 
 const iCalData = (iCalTestJSON as unknown as { data: string }).data
 const iCalEmptyData = (iCalTestEmptyJSON as unknown as { data: string }).data
 
 describe("iCal calendar extractor", () => {
+	beforeAll(() => MockDate.set(new Date("2020-10-15T15:03:12.592Z")))
+	afterAll(() => MockDate.reset())
 	it("should properly extract events from iCal formatted strings", () => {
 		const timeZone = "Europe/Paris"
 		const events = extractEventsFromCalendar(

--- a/tests/time-slots.spec.ts
+++ b/tests/time-slots.spec.ts
@@ -16,6 +16,7 @@ const baseConfig = {
 
 describe("Time Slot Finder", () => {
 	beforeEach(() => MockDate.reset())
+	afterAll(() => MockDate.reset())
 
 	it("should return slots even without calendar data", () => {
 		MockDate.set(new Date("2020-10-14T15:00:00.000Z"))


### PR DESCRIPTION
Due to a bug in `dayjs`, the offset is not correctly parse if the local offset differ from the mocked date offset (DST - summer and winter time).

Remove local testing before versioning.

Fix the parsing of the `to` and `from` date.