### PR TITLE
[Feature] Unavailable periods parameter format

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,29 +12,21 @@ plugins:
          enabled: false
 checks:
   argument-count:
-    config:
-      enabled: false
+    enabled: false
   complex-logic:
-    config:
-      enabled: false
+    enabled: false
   file-lines:
-    config:
-      enabled: false
+    enabled: false
   method-complexity:
-    config:
-      enabled: false
+    enabled: false
   method-count:
-    config:
-      enabled: false
+    enabled: false
   method-lines:
-    config:
-      enabled: false
+    enabled: false
   nested-control-flow:
-    config:
-      enabled: false
+    enabled: false
   return-statements:
-    config:
-      enabled: false
+    enabled: false
   similar-code:
     config:
       threshold: # language-specific defaults. an override will affect all languages.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ An API to get available time slots. It's possible to provide a calendar
 containing existing events.
 
 **Disclaimer**
-> This module is currently still in pre-version. Breaking changes may occurs in minor
-> versions. Use it with care.
+> This module is currently still in pre-version. **BREAKING CHANGES may occurs in MINOR
+> versions**. Use it with care.
 
 ## Features
 - Define slots duration
@@ -43,7 +43,7 @@ const slots = TimeSlotsFinder.getAvailableTimeSlotsInCalendar({
     configuration: {
         timeSlotDuration: 15,
         minAvailableTimeBeforeSlot: 5,
-        minTimeBeforeFirstSlot: 48,
+        minTimeBeforeFirstSlot: 48 * 60, // 48 hours in minutes
         availablePeriods: [{
             isoWeekDay: 5,
             shifts: [{ startTime: "10:00", endTime: "20:00" }] 
@@ -110,13 +110,16 @@ availablePeriods: [{
 /**
  * Periods where no booking is allowed.
  * 
- * The format of the strings must be `YYYY-MM-DD HH:mm` or `MM-DD HH:mm`. When no
- * year specified, the shift repeats every year.
- * An unavailable period MUST have the same date format for both startAt and endAt.
+ * Objet containing at least month and day values.
+ * If years are ommited, event repeat every years.
+ * If hour are ommited, all day is included: hour 00:00 is used for startAt and 23:59 is used for
+ * endAt.
+ * Month are 0 indexed, i.e. January is 0 and December is 11. 
+ * An unavailable period MUST have year defined for BOTH OR NONE of startAt and endAt.
  */
 unavailablePeriods: [{
-    startAt: string,
-    endAt: string,
+    startAt: { year?: number, month: number, day: number, hour?: number, minute?: number },
+    endAt: { year?: number, month: number, day: number, hour?: number, minute?: number },
 }]
 ```
 ```typescript
@@ -129,7 +132,7 @@ minAvailableTimeAfterSlot: number
 ```
 ```typescript
 /**
- * The minimum number of hours between the time of the search and the first slot
+ * The minimum number of minutes between the time of the search and the first slot
  * returned.
  */
 minTimeBeforeFirstSlot: number

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postversion": "git push && git push --tags && sh ./scripts/changesloglink.sh"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.14",
+    "@types/jest": "^26.0.15",
     "@types/node": "^14.11.8",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",

--- a/src/config-management.ts
+++ b/src/config-management.ts
@@ -140,7 +140,10 @@ export function _isUnavailablePeriodValid(period: Period): boolean {
 		&& (period.startAt.year == null) === (period.endAt.year == null)
 		&& _isPeriodMomentValid(period.startAt)
 		&& _isPeriodMomentValid(period.endAt)
-		/* If no year specified, the order can be reversed: the next year will be take for endAt */
+		/**
+		 * If the year value isn't specified, endAt can precede startAt, and
+		 * doing so will set the endAt year value to the following year if needed.
+		 */
 		&& (
 			period.startAt.year == null
 			/* Using the objectSupport DayJS plugin, types are not up to date */
@@ -176,7 +179,7 @@ function _isAvailablePeriodValid(availablePeriod: AvailablePeriod, index: number
 
 /**
  * Indicate either if the provided date string is valid or not.
- * @param {PeriodMoment} periodMoment The date string to check.
+ * @param {PeriodMoment} periodMoment The date object to check.
  * @returns {boolean}
  */
 function _isPeriodMomentValid(periodMoment: PeriodMoment) {
@@ -196,15 +199,9 @@ function _isPeriodMomentValid(periodMoment: PeriodMoment) {
 	/* The day check depends on month and year */
 	let day = dayjs().month(periodMoment.month)
 	if (periodMoment.year) { day = day.year(periodMoment.year) }
-	day = day.date(periodMoment.day)
-
-	const isDayValid = (
-		periodMoment.day >= 1 && periodMoment.day <= 31
-		&& day.month() === periodMoment.month
-	)
 
 	return (
-		isDayValid
+		periodMoment.day >= 1 && periodMoment.day <= day.daysInMonth()
 		&& (periodMoment.hour == null || (periodMoment.hour >= 0 && periodMoment.hour <= 23))
 		&& (periodMoment.minute == null || (periodMoment.minute >= 0 && periodMoment.minute <= 59))
 	)

--- a/src/dayjs-setup.ts
+++ b/src/dayjs-setup.ts
@@ -6,6 +6,7 @@ import customParseFormat from "dayjs/plugin/customParseFormat"
 import isoWeek from "dayjs/plugin/isoWeek"
 import isSameOrBefore from "dayjs/plugin/isSameOrBefore"
 import minMax from "dayjs/plugin/minMax"
+import objectSupport from "dayjs/plugin/objectSupport"
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
@@ -13,3 +14,4 @@ dayjs.extend(customParseFormat)
 dayjs.extend(isoWeek)
 dayjs.extend(isSameOrBefore)
 dayjs.extend(minMax)
+dayjs.extend(objectSupport)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,26 @@
 import { Dayjs } from "dayjs"
 
+export interface PeriodMoment {
+	/** The year of the moment. */
+	year?: number
+	/** The month of the moment. */
+	month: number
+	/** The day of the year of the moment. */
+	day: number
+	/** The hour of the moment. */
+	hour?: number
+	/** The minute of the moment. */
+	minute?: number
+}
+
 export interface Period {
 	/**
 	 * The moment the shift starts. The format of the string must be `YYYY-MM-DD HH:mm` or
 	 * `MM-DD HH:mm`.When no year specified, the shift repeats every year.
 	 */
-	startAt: string
+	startAt: PeriodMoment
 	/** The moment the shift end. The format MUST BE the same as the startAt property one. */
-	endAt: string
+	endAt: PeriodMoment
 }
 
 export interface Shift {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,12 +14,9 @@ export interface PeriodMoment {
 }
 
 export interface Period {
-	/**
-	 * The moment the shift starts. The format of the string must be `YYYY-MM-DD HH:mm` or
-	 * `MM-DD HH:mm`.When no year specified, the shift repeats every year.
-	 */
+	/** The moment the shift starts. When no year specified the shift repeats every year. */
 	startAt: PeriodMoment
-	/** The moment the shift end. The format MUST BE the same as the startAt property one. */
+	/** The moment the shift end. If year defined for `startAt`, it must be defined for `endAt`. */
 	endAt: PeriodMoment
 }
 

--- a/tests/config-management.spec.ts
+++ b/tests/config-management.spec.ts
@@ -306,6 +306,12 @@ describe("#isConfigurationValid", () => {
 			timeSlotDuration: 12,
 			timeZone: "Europe/Paris",
 			availablePeriods: [],
+			unavailablePeriods: "Something" as never,
+		})).toThrowError(new TimeSlotsFinderError(`A list of unavailable periods is expected`))
+		expect(() => isConfigurationValid({
+			timeSlotDuration: 12,
+			timeZone: "Europe/Paris",
+			availablePeriods: [],
 			unavailablePeriods: [{
 				startAt: "20201013T18:00:00:000Z" as never,
 				endAt: "20201013T20:00:00:000Z" as never,

--- a/tests/config-management.spec.ts
+++ b/tests/config-management.spec.ts
@@ -72,67 +72,94 @@ describe("#_mergeOverlappingShifts", () => {
 	})
 })
 
-describe("#_isUnworkedShiftValid", () => {
+describe("#_isUnavailablePeriodValid", () => {
 	it("should return false for invalid dates", () => {
 		expect(_isUnavailablePeriodValid({
-			startAt: "",
-			endAt: "",
+			startAt: {} as never,
+			endAt: {} as never,
 		})).toBe(false)
 		expect(_isUnavailablePeriodValid({
-			startAt: "1994-10-12 23:55",
-			endAt: "",
+			startAt: { year: 1994, month: 9, day: 12, hour: 23, minute: 55 },
+			endAt: {} as never,
 		})).toBe(false)
 		expect(_isUnavailablePeriodValid({
-			startAt: "",
-			endAt: "1994-10-12 23:55",
+			startAt: {} as never,
+			endAt: { year: 1994, month: 9, day: 12, hour: 23, minute: 55 },
 		})).toBe(false)
 		expect(_isUnavailablePeriodValid({
-			startAt: "1994-10-12 23:55",
-			endAt: "1994-13-12 23:55",
+			startAt: { year: 1994, day: 12, hour: 23, minute: 55 } as never,
+			endAt: { year: 1994, month: 9, day: 12, hour: 23, minute: 55 },
+		})).toBe(false)
+		/* 2021 is not a leap year: February 29th does not exist. */
+		expect(_isUnavailablePeriodValid({
+			startAt: { year: 2021, month: 1, day: 29, hour: 23, minute: 55 },
+			endAt: { year: 2021, month: 9, day: 12, hour: 23, minute: 55 },
 		})).toBe(false)
 		expect(_isUnavailablePeriodValid({
-			startAt: "1994-10-12 23:55",
-			endAt: "1994-10-13 24:55",
+			startAt: { year: 1994, hour: 23, minute: 55 } as never,
+			endAt: { year: 1994, month: 9, day: 12, hour: 23, minute: 55 },
 		})).toBe(false)
 		expect(_isUnavailablePeriodValid({
-			startAt: "10-12 23:55",
-			endAt: "10-13 23:75",
+			startAt: "1994-10-12 23:55" as never,
+			endAt: "1994-10-13 23:55" as never,
+		})).toBe(false)
+		expect(_isUnavailablePeriodValid({
+			startAt: "10-12 23:55" as never,
+			endAt: "10-13 23:55" as never,
 		})).toBe(false)
 	})
 	it("should return false if endAt is equal or before startAt", () => {
 		expect(_isUnavailablePeriodValid({
-			startAt: "1994-10-12 23:55",
-			endAt: "1994-10-11 23:55",
+			startAt: { year: 1994, month: 10, day: 12, hour: 23, minute: 55 },
+			endAt: { year: 1994, month: 10, day: 11, hour: 23, minute: 55 },
 		})).toBe(false)
 	})
-	it("should return false if endAt and startAt have different format", () => {
+	it("should return false if only one of endAt and startAt have year defined", () => {
 		expect(_isUnavailablePeriodValid({
-			startAt: "10-12 23:55",
-			endAt: "1994-10-13 23:55",
+			startAt: { month: 10, day: 12, hour: 23, minute: 55 },
+			endAt: { year: 1994, month: 10, day: 13, hour: 23, minute: 55 },
 		})).toBe(false)
 		expect(_isUnavailablePeriodValid({
-			startAt: "1994-10-12 23:55",
-			endAt: "10-13 23:55",
+			startAt: { year: 1994, month: 10, day: 12, hour: 23, minute: 55 },
+			endAt: { month: 10, day: 13, hour: 23, minute: 55 },
 		})).toBe(false)
 	})
 	it("should return true if endAt is before startAt without a specific year", () => {
 		expect(_isUnavailablePeriodValid({
-			startAt: "12-24 23:55",
-			endAt: "01-01 23:55",
+			startAt: { month: 11, day: 24, hour: 23, minute: 55 },
+			endAt: { month: 1, day: 1, hour: 23, minute: 55 },
 		})).toBe(true)
+	})
+	it("should return true if hour and minute are not defined", () => {
+		expect(_isUnavailablePeriodValid({
+			startAt: { month: 11, day: 24 },
+			endAt: { month: 1, day: 1 },
+		})).toBe(true)
+	})
+	it("should return true if minute are not defined", () => {
+		expect(_isUnavailablePeriodValid({
+			startAt: { month: 11, day: 24, hour: 23 },
+			endAt: { month: 0, day: 1, hour: 23 },
+		})).toBe(true)
+	})
+	it("should return false if hour are not defined but minute are", () => {
+		expect(_isUnavailablePeriodValid({
+			startAt: { month: 11, day: 24, minute: 23 },
+			endAt: { month: 0, day: 1, minute: 23 },
+		})).toBe(false)
 	})
 	it(`should return true if endAt and startAt have same valid format and are correctly ordered`, () => {
 		expect(_isUnavailablePeriodValid({
-			startAt: "1994-12-24 23:55",
-			endAt: "1995-01-01 23:55",
+			startAt: { year: 1994, month: 11, day: 24, hour: 23, minute: 55 },
+			endAt: { year: 1995, month: 1, day: 1, hour: 23, minute: 55 },
 		})).toBe(true)
 		expect(_isUnavailablePeriodValid({
-			startAt: "1994-12-24 23:55",
-			endAt: "1994-12-26 23:55",
+			startAt: { year: 1994, month: 11, day: 24, hour: 23, minute: 55 },
+			endAt: { year: 1994, month: 11, day: 26, hour: 23, minute: 55 },
 		})).toBe(true)
 		expect(_isUnavailablePeriodValid({
-			startAt: "12-24 23:55",
-			endAt: "12-26 23:55",
+			startAt: { month: 11, day: 24, hour: 23, minute: 55 },
+			endAt: { month: 11, day: 26, hour: 23, minute: 55 },
 		})).toBe(true)
 	})
 })
@@ -280,8 +307,8 @@ describe("#isConfigurationValid", () => {
 			timeZone: "Europe/Paris",
 			availablePeriods: [],
 			unavailablePeriods: [{
-				startAt: "20201013T18:00:00:000Z",
-				endAt: "20201013T20:00:00:000Z",
+				startAt: "20201013T18:00:00:000Z" as never,
+				endAt: "20201013T20:00:00:000Z" as never,
 			}],
 		})).toThrowError(new TimeSlotsFinderError(`Unavailable period nº1 is invalid`))
 		expect(() => isConfigurationValid({
@@ -289,8 +316,8 @@ describe("#isConfigurationValid", () => {
 			timeZone: "Europe/Paris",
 			availablePeriods: [],
 			unavailablePeriods: [{
-				startAt: "2020-10-13 18:00",
-				endAt: "10-13 20:00",
+				startAt: { year: 2020, month: 10, day: 13, hour: 18, minute: 0 },
+				endAt: { month: 10, day: 13, hour: 20, minute: 0 },
 			}],
 		})).toThrowError(new TimeSlotsFinderError(`Unavailable period nº1 is invalid`))
 		expect(() => isConfigurationValid({
@@ -370,8 +397,8 @@ describe("#isConfigurationValid", () => {
 				}],
 			}],
 			unavailablePeriods: [{
-				startAt: "10-13 18:00",
-				endAt: "10-01 20:00",
+				startAt: { month: 10, day: 13, hour: 18, minute: 0 },
+				endAt: { month: 10, day: 1, hour: 20, minute: 0 },
 			}],
 		})).toBe(true)
 		expect(isConfigurationValid({

--- a/tests/time-slots.spec.ts
+++ b/tests/time-slots.spec.ts
@@ -357,6 +357,13 @@ describe("Time Slot Finder", () => {
 		const slots5 = getAvailableTimeSlotsInCalendar({
 			configuration: {
 				...baseConfig,
+				availablePeriods: [{
+					isoWeekDay: 4,
+					shifts: [{ startTime: "10:00", endTime: "20:00" }]
+				}, {
+					isoWeekDay: 7,
+					shifts: [{ startTime: "10:00", endTime: "20:00" }]
+				}],
 				unavailablePeriods: [{
 					startAt: { month: 9, day: 16 },
 					endAt: { month: 9, day: 17 }
@@ -375,8 +382,8 @@ describe("Time Slot Finder", () => {
 			configuration: {
 				...baseConfig,
 				unavailablePeriods: [{
-					startAt: { year: 2021, month: 9, day: 16, hour: 16 },
-					endAt: { year: 2021, month: 9, day: 16, hour: 17, minute: 30 }
+					startAt: { year: 2020, month: 9, day: 16, hour: 16 },
+					endAt: { year: 2020, month: 9, day: 16, hour: 17, minute: 30 }
 				}],
 			},
 			from: new Date("2020-10-16T15:45:00.000+02:00"),

--- a/tests/time-slots.spec.ts
+++ b/tests/time-slots.spec.ts
@@ -289,7 +289,10 @@ describe("Time Slot Finder", () => {
 		const slots = getAvailableTimeSlotsInCalendar({
 			configuration: {
 				...baseConfig,
-				unavailablePeriods: [{ startAt: "2020-10-16 12:30", endAt: "2020-10-16 14:00" }],
+				unavailablePeriods: [{
+					startAt: { year: 2020, month: 9, day: 16, hour: 12, minute: 30 },
+					endAt: { year: 2020, month: 9, day: 16, hour: 14, minute: 0 }
+				}],
 			},
 			from: new Date("2020-10-16T11:30:00.000+02:00"),
 			to: new Date("2020-10-16T15:00:00.000+02:00"),
@@ -307,7 +310,10 @@ describe("Time Slot Finder", () => {
 		const slots2 = getAvailableTimeSlotsInCalendar({
 			configuration: {
 				...baseConfig,
-				unavailablePeriods: [{ startAt: "2019-10-16 12:30", endAt: "2019-10-16 14:00" }],
+				unavailablePeriods: [{
+					startAt: { year: 2019, month: 9, day: 16, hour: 12, minute: 30 },
+					endAt: { year: 2019, month: 9, day: 16, hour: 14, minute: 0 }
+				}],
 			},
 			from: new Date("2020-10-16T11:30:00.000+02:00"),
 			to: new Date("2020-10-16T15:00:00.000+02:00"),
@@ -317,7 +323,10 @@ describe("Time Slot Finder", () => {
 		const slots3 = getAvailableTimeSlotsInCalendar({
 			configuration: {
 				...baseConfig,
-				unavailablePeriods: [{ startAt: "10-16 12:30", endAt: "10-16 14:00" }],
+				unavailablePeriods: [{
+					startAt: { month: 9, day: 16, hour: 12, minute: 30 },
+					endAt: { month: 9, day: 16, hour: 14, minute: 0 }
+				}],
 			},
 			from: new Date("2020-10-16T11:30:00.000+02:00"),
 			to: new Date("2020-10-16T15:00:00.000+02:00"),
@@ -327,6 +336,57 @@ describe("Time Slot Finder", () => {
 			.toBe(new Date("2020-10-16T11:30:00.000+02:00").toString())
 		expect(slots3[7].startAt.toString())
 			.toBe(new Date("2020-10-16T14:45:00.000+02:00").toString())
+
+		const slots4 = getAvailableTimeSlotsInCalendar({
+			configuration: {
+				...baseConfig,
+				unavailablePeriods: [{
+					startAt: { month: 9, day: 16, hour: 12, minute: 30 },
+					endAt: { month: 9, day: 16, hour: 14 }
+				}],
+			},
+			from: new Date("2020-10-16T12:15:00.000+02:00"),
+			to: new Date("2020-10-16T15:00:00.000+02:00"),
+		})
+		expect(slots4.length).toBe(5)
+		expect(slots4[0].startAt.toString())
+			.toBe(new Date("2020-10-16T12:15:00.000+02:00").toString())
+		expect(slots4[1].startAt.toString())
+			.toBe(new Date("2020-10-16T14:00:00.000+02:00").toString())
+
+		const slots5 = getAvailableTimeSlotsInCalendar({
+			configuration: {
+				...baseConfig,
+				unavailablePeriods: [{
+					startAt: { month: 9, day: 16 },
+					endAt: { month: 9, day: 17 }
+				}],
+			},
+			from: new Date("2020-10-15T19:45:00.000+02:00"),
+			to: new Date("2020-10-18T10:15:00.000+02:00"),
+		})
+		expect(slots5.length).toBe(2)
+		expect(slots5[0].startAt.toString())
+			.toBe(new Date("2020-10-15T19:45:00.000+02:00").toString())
+		expect(slots5[1].startAt.toString())
+			.toBe(new Date("2020-10-18T10:00:00.000+02:00").toString())
+
+		const slots6 = getAvailableTimeSlotsInCalendar({
+			configuration: {
+				...baseConfig,
+				unavailablePeriods: [{
+					startAt: { year: 2021, month: 9, day: 16, hour: 16 },
+					endAt: { year: 2021, month: 9, day: 16, hour: 17, minute: 30 }
+				}],
+			},
+			from: new Date("2020-10-16T15:45:00.000+02:00"),
+			to: new Date("2020-10-16T17:45:00.000+02:00"),
+		})
+		expect(slots6.length).toBe(2)
+		expect(slots6[0].startAt.toString())
+			.toBe(new Date("2020-10-16T15:45:00.000+02:00").toString())
+		expect(slots6[1].startAt.toString())
+			.toBe(new Date("2020-10-16T17:30:00.000+02:00").toString())
 	})
 	it("should throw for invalid from and/or to parameters", () => {
 		expect(() => getAvailableTimeSlotsInCalendar({

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,7 +588,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.x", "@types/jest@^26.0.14":
+"@types/jest@26.x", "@types/jest@^26.0.15":
   version "26.0.15"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.15.tgz#12e02c0372ad0548e07b9f4e19132b834cb1effe"
   integrity sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==


### PR DESCRIPTION
The goal of this PR is to update the API to simplify the definition of "full day" unavailabilities.

We update the format to make `hour` and `minute` optional in addition of the already optional `year`.
This is done with UI mind. Most of the end-users may want to define unavailable periods for holidays: in this kind of case, the full days will be unavailable.

For Christmas vacation, this could give something like: `{ startAt: { month: 11, day: 25 }, endAt: { month:0, day: 1 }}`.

This PR also fix documentation issue #31.