### PR TITLE
[BugFix] Add missing control for time zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A **TimeSlot** is represented as follows:
 ### Configuration options
 
 ```typescript
-/* The length of the time slots in minutes. */
+/* Required. The length of the time slots in minutes. */
 timeSlotDuration: number
 ```
 ```typescript
@@ -97,7 +97,7 @@ timeSlotDuration: number
 slotStartMinuteStep: number
 ```
 ```typescript
-/* Bookable periods for each day of the week. */
+/* Required. Bookable periods for each day of the week. */
 availablePeriods: [{
     isoWeekDay: number, // 1 (Monday) - 7 (Sunday)
     shifts: [{
@@ -142,7 +142,7 @@ minTimeBeforeFirstSlot: number
 maxDaysBeforeLastSlot: number
 ```
 ```typescript
-/* The time zone used through all the configuration. */
+/* Required. The time zone used through all the configuration. */
 timeZone: string
 ```
 [See the time zones list here.](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)

--- a/src/config-management.ts
+++ b/src/config-management.ts
@@ -61,11 +61,7 @@ function _checkPrimitiveValue(configuration: TimeSlotsFinderConfiguration): bool
 	if (!_nullOrGreaterThanOrEqualTo(1, configuration.maxDaysBeforeLastSlot)) {
 		throw new TimeSlotsFinderError(`The number of days before latest slot must be at least 1`)
 	}
-	try {
-		dayjs().tz(configuration.timeZone)
-	} catch (_) {
-		throw new TimeSlotsFinderError(`Invalid time zone: ${configuration.timeZone}`)
-	}
+	_checkTimeZone(configuration.timeZone)
 
 	const minBeforeFirst = configuration.minTimeBeforeFirstSlot
 	const maxBeforeLast = configuration.maxDaysBeforeLastSlot
@@ -73,6 +69,17 @@ function _checkPrimitiveValue(configuration: TimeSlotsFinderConfiguration): bool
 		throw new TimeSlotsFinderError(`The first possible slot will always be after last one possible (see minTimeBeforeFirstSlot and maxDaysBeforeLastSlot)`)
 	}
 	return true
+}
+
+function _checkTimeZone(timeZone: string) {
+	if (!timeZone) {
+		throw new TimeSlotsFinderError(`Missing time zone`)
+	}
+	try {
+		dayjs().tz(timeZone)
+	} catch (_) {
+		throw new TimeSlotsFinderError(`Invalid time zone: ${timeZone}`)
+	}
 }
 
 function _nullOrGreaterThanOrEqualTo(limit: number, value?: number): boolean {

--- a/tests/config-management.spec.ts
+++ b/tests/config-management.spec.ts
@@ -291,6 +291,38 @@ describe("#isConfigurationValid", () => {
 		})).toThrowError(new TimeSlotsFinderError(`Invalid time zone: InvalidTZ`))
 		expect(() => isConfigurationValid({
 			timeSlotDuration: 12,
+			availablePeriods: [{
+				isoWeekDay: 1,
+				shifts: [{
+					startTime: "19:00",
+					endTime: "21:00",
+				}],
+			}],
+		} as never)).toThrowError(new TimeSlotsFinderError(`Missing time zone`))
+		expect(() => isConfigurationValid({
+			timeSlotDuration: 12,
+			timeZone: null as never,
+			availablePeriods: [{
+				isoWeekDay: 1,
+				shifts: [{
+					startTime: "19:00",
+					endTime: "21:00",
+				}],
+			}],
+		})).toThrowError(new TimeSlotsFinderError(`Missing time zone`))
+		expect(() => isConfigurationValid({
+			timeSlotDuration: 12,
+			timeZone: "",
+			availablePeriods: [{
+				isoWeekDay: 1,
+				shifts: [{
+					startTime: "19:00",
+					endTime: "21:00",
+				}],
+			}],
+		})).toThrowError(new TimeSlotsFinderError(`Missing time zone`))
+		expect(() => isConfigurationValid({
+			timeSlotDuration: 12,
 			timeZone: "Europe/Paris",
 			availablePeriods: null as never,
 		})).toThrowError(new TimeSlotsFinderError(`A list of available periods is expected`))


### PR DESCRIPTION
- Update configuration checking to ensure that configuration missing `timeZone` params will be rejected.
- Complete `README.md` to indicate required parameters.